### PR TITLE
Lets maven create source and javadoc jars.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,40 @@
                     <connectionType>developerConnection</connectionType>
                 </configuration>
             </plugin>
+
+            <!-- ensure that sharkfw-core-VERSION-source.jar is created -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- ensure that sharkfw-core-VERSION-javadoc.jar is created -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.4</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <failOnError>false</failOnError>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 


### PR DESCRIPTION
The source and javadoc jars are currently not created by maven.  

This is required in order to view documentation of the sharkfw inside an modern IDE 
and it is one requirement to publish this framework into a public maven repository. 
