### PR TITLE
Refactoring: Fixed smells in the code

### DIFF
--- a/src/main/java/net/sharkfw/asip/engine/serializer/XMLSerializer.java
+++ b/src/main/java/net/sharkfw/asip/engine/serializer/XMLSerializer.java
@@ -141,6 +141,24 @@ public class XMLSerializer {
         }
 
 
+        openTagWritten = semanticNetConstructor(tagEnum, tag, semanticNet, buf, openTagWritten);
+
+        if (openTagWritten) {
+            if (semanticNet) {
+                buf.append(this.endTag(PREDICATES_TAG));
+            } else {
+                buf.append(this.endTag(SUB_SUPER_TAG));
+            }
+        }
+
+        if (buf.length() > 0) {
+            return buf.toString();
+        } else {
+            return null;
+        }
+    }
+
+    private boolean semanticNetConstructor(Enumeration<SemanticTag> tagEnum, SemanticTag tag, boolean semanticNet, StringBuilder buf, boolean openTagWritten) {
         if (semanticNet) {
 
             // Semantic Net
@@ -207,7 +225,7 @@ public class XMLSerializer {
                                 buf.append(this.endTag(SI_TAG));
                                 buf.append(this.endTag(TARGET_TAG));
 
-                                // end 
+                                // end
                                 buf.append(this.endTag(PREDICATE_TAG));
                             }
                         }
@@ -261,26 +279,13 @@ public class XMLSerializer {
                         buf.append(this.endTag(SI_TAG));
                         buf.append(this.endTag(TARGET_TAG));
 
-                        // end 
+                        // end
                         buf.append(this.endTag(SUPER_TAG));
                     }
                 }
             } while (tagEnum.hasMoreElements());
         }
-
-        if (openTagWritten) {
-            if (semanticNet) {
-                buf.append(this.endTag(PREDICATES_TAG));
-            } else {
-                buf.append(this.endTag(SUB_SUPER_TAG));
-            }
-        }
-
-        if (buf.length() > 0) {
-            return buf.toString();
-        } else {
-            return null;
-        }
+        return openTagWritten;
     }
 
     private String serializeTag(SemanticTag tag) throws SharkKBException {

--- a/src/main/java/net/sharkfw/asip/serialization/ASIPMessageSerializer.java
+++ b/src/main/java/net/sharkfw/asip/serialization/ASIPMessageSerializer.java
@@ -255,6 +255,11 @@ public class ASIPMessageSerializer {
             }
         }
 
+        if (ASIPPerformer(message, serializationHolder, command, content)) return false;
+        return true;
+    }
+
+    private static boolean ASIPPerformer(ASIPInMessage message, ASIPSerializationHolder serializationHolder, int command, JSONObject content) {
         switch (command) {
             case ASIPMessage.ASIP_EXPOSE:
                 try {
@@ -262,13 +267,13 @@ public class ASIPMessageSerializer {
                     message.setInterest(interest);
                 } catch (SharkKBException e) {
                     e.printStackTrace();
-                    return false;
+                    return true;
                 }
                 break;
             case ASIPMessage.ASIP_INSERT:
                 if(serializationHolder.getContent()==null){
                     L.d("No content available", CLASS);
-                    return false;
+                    return true;
                 }
                 try {
                     ASIPKnowledgeConverter knowledgeConverter =
@@ -278,18 +283,18 @@ public class ASIPMessageSerializer {
                     message.setKnowledge(knowledgeConverter.getKnowledge());
                 } catch (SharkKBException | ASIPSerializerException e) {
                     e.printStackTrace();
-                    return false;
+                    return true;
                 }
                 break;
             case ASIPMessage.ASIP_RAW:
                 if(serializationHolder.getContent()==null){
                     L.d("No content available", CLASS);
-                    return false;
+                    return true;
                 }
                 byte[] raw = serializationHolder.getContent();
                 message.setRaw(new ByteArrayInputStream(raw));
                 break;
         }
-        return true;
+        return false;
     }
 }

--- a/src/main/java/net/sharkfw/knowledgeBase/FPSet.java
+++ b/src/main/java/net/sharkfw/knowledgeBase/FPSet.java
@@ -51,7 +51,7 @@ public class FPSet {
         fpSet.setFP(directionFP, ASIPSpace.DIM_DIRECTION);
     }
     
-    private int dimension2index(int dim) {
+    private int dimensionToIndex(int dim) {
         switch(dim) {
             case ASIPSpace.DIM_TOPIC: return 0;
             case ASIPSpace.DIM_TYPE: return 1;
@@ -67,7 +67,7 @@ public class FPSet {
     }
 
     private void setFP(FragmentationParameter fp, int dimension) {
-        int index = this.dimension2index(dimension);
+        int index = this.dimensionToIndex(dimension);
         fps[index] = fp;
     }
 
@@ -77,7 +77,7 @@ public class FPSet {
      * return fragmentation parameters in any case.
      */
     public FragmentationParameter getFP(int dimension) {
-        int index = this.dimension2index(dimension);
+        int index = this.dimensionToIndex(dimension);
         
         if(this.fps[index] == null) {
             return FragmentationParameter.getZeroFP();


### PR DESCRIPTION
 

Refactoring Name: Extract Method: 

 

After running DesigniteJava on the forked project, it has two “Long Method” smells. 

 

Therefore, separate methods have been extracted from them. 

 

1) 

Location: src\main\java\net\sharkfw\asip\serialization\ASIPMessageSerializer.java 

 

The method deserializeInMessage is very long and it has been detected as a smell. Therefore, a new method named ASIPPerformer has been extracted from it. 

 

Link (before commit): 

https://github.com/callmehetch/SharkFW/blob/28bef0a036da8cb445a505326019f8b4dec5dcf0/src/main/java/net/sharkfw/asip/serialization/ASIPMessageSerializer.java 

 

 

Link (after commit):  

https://github.com/callmehetch/SharkFW/blob/aba4a75012780822d0fe628ca4fb04b0b8b453c0/src/main/java/net/sharkfw/asip/serialization/ASIPMessageSerializer.java 

 

 

2) 

Location: \src\main\java\net\sharkfw\asip\engine\serializer\XMLSerializer.java 

 

The method serializeRealations is very long and it has been detected as a smell. Therefore, a new method named semanticNetConstructor has been extracted from it.  

Link (before commit): 

https://github.com/callmehetch/SharkFW/blob/b273388fdbbce7a3fd753306f7b0b8158fe08332/src/main/java/net/sharkfw/asip/engine/serializer/XMLSerializer.java 

 

 

Link (after commit):  

https://github.com/callmehetch/SharkFW/blob/3b260ce78e953182eae8d86203dfc7c3fa4fc904/src/main/java/net/sharkfw/asip/engine/serializer/XMLSerializer.java 

 

The program is being successfully compiled after extract method refactoring: 

 

Refactoring Name: Rename Variable/Method: 

 

Usually, the names of the methods are supposed to be in camel case and numerical values are supposed to be spelt. In the diagram, if we look at the fist naming convention, we can clearly spot the difference for the second naming convention. Therefore, the method name is changed from dimension2index to dimensionToIndex. 

 

 

Location: src/main/java/net/sharkfw/knowledgeBase/FPSet.java 

  

Link (before commit): 

https://github.com/callmehetch/SharkFW/blob/47b3f7505529daf20a9ac0d8eff8ce9f6e44bd2b/src/main/java/net/sharkfw/knowledgeBase/FPSet.java 

 

Link (after commit):  

https://github.com/callmehetch/SharkFW/blob/27970b138ab1eb4b974a4fbb23fd6088a36364df/src/main/java/net/sharkfw/knowledgeBase/FPSet.java 

 

 

2) 

The variable SHARK_BROADCAST_TYPE_SI renamed to SHARK_BROADCAST_URL as it contains an URL link. 

 

Location: src/main/java/net/sharkfw/knowledgeBase/FPSet.java 

  

Link (before commit): 

https://github.com/callmehetch/SharkFW/blob/988cd8a75e5ca64febfbff4219c525e9c14a231b/src/main/java/net/sharkfw/knowledgeBase/broadcast/BroadcastManager.java 

 

Link (after commit):  

https://github.com/callmehetch/SharkFW/blob/7c88b3dd5847176c64624e513f07622883b4bc4a/src/main/java/net/sharkfw/knowledgeBase/broadcast/BroadcastManager.java 

 

The program is being successfully compiled after rename method refactoring.